### PR TITLE
Display lobby after match selection

### DIFF
--- a/script.js
+++ b/script.js
@@ -67,6 +67,7 @@ function hostPrivate(){
         history.replaceState(null, '', '?room='+room);
     }
     document.getElementById('titleScreen').classList.add('hidden');
+    document.getElementById('lobby').classList.remove('hidden');
     document.getElementById('roomInfo').textContent = 'Share this link: ' + window.location.href;
     socket.emit('join', room);
 }
@@ -74,6 +75,7 @@ function hostPrivate(){
 function joinPublic(){
     inQueue = true;
     document.getElementById('titleScreen').classList.add('hidden');
+    document.getElementById('lobby').classList.remove('hidden');
     document.getElementById('roomInfo').textContent = 'Finding opponent...';
     socket.emit('queue');
 }


### PR DESCRIPTION
## Summary
- reveal the lobby screen when selecting Private Match or Public Match

## Testing
- `npm install`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_684b6488a8b083269f7e836d82ce35be